### PR TITLE
Created fixtures, table, table tests, and table storybook

### DIFF
--- a/frontend/src/fixtures/diningCommonsFixtures.js
+++ b/frontend/src/fixtures/diningCommonsFixtures.js
@@ -1,0 +1,26 @@
+const diningCommonsFixtures = {
+  oneDiningCommons: [
+    {
+      code: "carrillo",
+      name: "Carrillo",
+    },
+  ],
+  threeDiningCommons: [
+    {
+      code: "carrillo",
+      name: "Carrillo",
+    },
+
+    {
+      code: "de-la-guerra",
+      name: "De La Guerra",
+    },
+
+    {
+      code: "ortega",
+      name: "Ortega",
+    },
+  ],
+};
+
+export { diningCommonsFixtures };

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import OurTable from "main/components/OurTable";
 
 export default function DiningCommonsTable({ diningCommonsData }) {
@@ -6,6 +7,7 @@ export default function DiningCommonsTable({ diningCommonsData }) {
     {
       Header: "Code",
       accessor: "code",
+      Cell: ({ value }) => <Link to={`/diningcommons/${value}`}>{value}</Link>,
     },
     {
       Header: "Name",

--- a/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
+++ b/frontend/src/main/components/DiningCommons/DiningCommonsTable.js
@@ -1,0 +1,23 @@
+import React from "react";
+import OurTable from "main/components/OurTable";
+
+export default function DiningCommonsTable({ diningCommonsData }) {
+  const columns = [
+    {
+      Header: "Code",
+      accessor: "code",
+    },
+    {
+      Header: "Name",
+      accessor: "name",
+    },
+  ];
+
+  return (
+    <OurTable
+      data={diningCommonsData}
+      columns={columns}
+      testid={"DiningCommonsTable"}
+    />
+  );
+}

--- a/frontend/src/stories/components/DiningCommons/DiningCommonsTable.stories.js
+++ b/frontend/src/stories/components/DiningCommons/DiningCommonsTable.stories.js
@@ -1,0 +1,31 @@
+import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
+
+export default {
+  title: "components/DiningCommons/DiningCommonsTable",
+  component: DiningCommonsTable,
+};
+
+const Template = (args) => {
+  return <DiningCommonsTable {...args} />;
+};
+
+export const Sample = Template.bind({});
+
+Sample.args = {
+  diningCommonsData: [
+    {
+      code: "carrillo",
+      name: "Carrillo",
+    },
+
+    {
+      code: "de-la-guerra",
+      name: "De La Guerra",
+    },
+
+    {
+      code: "ortega",
+      name: "Ortega",
+    },
+  ],
+};

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -44,11 +44,19 @@ describe("UserTable tests", () => {
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-code`),
     ).toHaveTextContent("carrillo");
+    const carrilloLink = screen.getByText("carrillo");
+    expect(carrilloLink).toHaveAttribute("href", "/diningcommons/carrillo");
+
     expect(
       screen.getByTestId(`${testId}-cell-row-1-col-code`),
     ).toHaveTextContent("de-la-guerra");
+    const dlgLink = screen.getByText("de-la-guerra");
+    expect(dlgLink).toHaveAttribute("href", "/diningcommons/de-la-guerra");
+
     expect(
       screen.getByTestId(`${testId}-cell-row-2-col-code`),
     ).toHaveTextContent("ortega");
+    const ortegaLink = screen.getByText("ortega");
+    expect(ortegaLink).toHaveAttribute("href", "/diningcommons/ortega");
   });
 });

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -1,0 +1,54 @@
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
+import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+describe("UserTable tests", () => {
+  const queryClient = new QueryClient();
+
+  test("Has the expected column headers and content", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DiningCommonsTable
+            diningCommonsData={diningCommonsFixtures.threeDiningCommons}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = ["Code", "Name"];
+    const expectedFields = ["code", "name"];
+    const testId = "DiningCommonsTable";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-code`),
+    ).toHaveTextContent("carrillo");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-code`),
+    ).toHaveTextContent("de-la-guerra");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-code`),
+    ).toHaveTextContent("ortega");
+  });
+});

--- a/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
+++ b/frontend/src/tests/components/DiningCommons/DiningCommonsTable.test.js
@@ -1,10 +1,8 @@
-import { fireEvent, render, waitFor, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { diningCommonsFixtures } from "fixtures/diningCommonsFixtures";
 import DiningCommonsTable from "main/components/DiningCommons/DiningCommonsTable";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import axios from "axios";
-import AxiosMockAdapter from "axios-mock-adapter";
 
 const mockedNavigate = jest.fn();
 


### PR DESCRIPTION
# Frontend 1

Closes Issue #10 which inherits from #39 

### Fixtures
Created a set of fixtures for the DiningCommons which look like this:
- oneDiningCommons
```
    {
      code: "carrillo",
      name: "Carrillo",
    }
```

- threeDiningCommons 
```
    {
      code: "carrillo",
      name: "Carrillo",
    },
    {
      code: "de-la-guerra",
      name: "De La Guerra",
    },
    {
      code: "ortega",
      name: "Ortega",
    }
```

### Table
Simple view of the table created (links here don't work just linked to show that the table has links in code):
| Code                                | Name              |
|-------------------------------------|-------------------|
| [carrillo](#link-to-carrillo)       | Carrillo          |
| [de-la-guerra](#link-to-de-la-guerra) | De La Guerra      |
| [ortega](#link-to-ortega)           | Ortega            |
| [portola](#link-to-portola)         | Portola           |

### Storybook
Docs tab for Storybook for DiningCommonsTable:
<img width="1480" alt="Screenshot 2024-11-16 at 9 59 16 PM" src="https://github.com/user-attachments/assets/09ae88a9-755e-423c-8b7f-1de0a9f7d102">
Sample tab for Storybook for DiningCommonsTable:
<img width="1512" alt="Screenshot 2024-11-16 at 10 00 20 PM" src="https://github.com/user-attachments/assets/2ff9723f-6705-4597-a947-c93d6c14e782">

### Testing:
Ran all three tests and code passes all three tests locally:
```
npm test
npx stryker run
npm run coverage
```




