### PR TITLE
Add placeholder page /moderate accessible only to admins and link in menu bar as "Moderate"

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
-import ModeratePage from "main/pages/ModeratePage"; 
+import ModeratePage from "main/pages/ModeratePage";
 
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
@@ -23,10 +23,9 @@ function App() {
         <Route exact path="/profile" element={<ProfilePage />} />
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <>
-          <Route exact path="/admin/users" element={<AdminUsersPage />} />
-          <Route exact path="/moderate" element={<ModeratePage />} /> 
-        </>
-          
+            <Route exact path="/admin/users" element={<AdminUsersPage />} />
+            <Route exact path="/moderate" element={<ModeratePage />} />
+          </>
         )}
         {hasRole(currentUser, "ROLE_USER") && (
           <>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
+import ModeratePage from "main/pages/ModeratePage"; 
 
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
@@ -21,7 +22,11 @@ function App() {
         <Route exact path="/" element={<HomePage />} />
         <Route exact path="/profile" element={<ProfilePage />} />
         {hasRole(currentUser, "ROLE_ADMIN") && (
+          <>
           <Route exact path="/admin/users" element={<AdminUsersPage />} />
+          <Route exact path="/moderate" element={<ModeratePage />} /> 
+        </>
+          
         )}
         {hasRole(currentUser, "ROLE_USER") && (
           <>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -41,6 +41,11 @@ export default function AppNavbar({
                 <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
               </>
             )}
+             {hasRole(currentUser, "ROLE_ADMIN") && (
+              <Nav.Link as={Link} to="/moderate">
+                Moderate
+              </Nav.Link>
+            )}
           </Nav>
 
           <>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -41,7 +41,7 @@ export default function AppNavbar({
                 <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
               </>
             )}
-             {hasRole(currentUser, "ROLE_ADMIN") && (
+            {hasRole(currentUser, "ROLE_ADMIN") && (
               <Nav.Link as={Link} to="/moderate">
                 Moderate
               </Nav.Link>

--- a/frontend/src/main/pages/ModeratePage.js
+++ b/frontend/src/main/pages/ModeratePage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ModeratePage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>moderate page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -164,6 +164,30 @@ describe("AppNavbar tests", () => {
     expect(link.getAttribute("href")).toBe("/placeholder");
   });
 
+  test("renders the moderate link correctly", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+    const systemInfo = systemInfoFixtures.showingBoth;
+
+    const doLogin = jest.fn();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AppNavbar
+            currentUser={currentUser}
+            systemInfo={systemInfo}
+            doLogin={doLogin}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Moderate");
+    const link = screen.getByText("Moderate");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/moderate");
+  });
+
   test("Placeholder link does NOT show when not logged in", async () => {
     const currentUser = null;
     const systemInfo = systemInfoFixtures.showingBoth;

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -164,11 +164,10 @@ describe("AppNavbar tests", () => {
     expect(link.getAttribute("href")).toBe("/placeholder");
   });
 
-
   test("renders the moderate link correctly", async () => {
     const currentUser = currentUserFixtures.adminUser;
-    
-    onst systemInfo = systemInfoFixtures.showingBoth;
+
+    const systemInfo = systemInfoFixtures.showingBoth;
 
     const doLogin = jest.fn();
 
@@ -184,14 +183,12 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
-
     await screen.findByText("Moderate");
     const link = screen.getByText("Moderate");
     expect(link).toBeInTheDocument();
     expect(link.getAttribute("href")).toBe("/moderate");
-
   });
-    
+
   test("renders myreviews link correctly", async () => {
     const currentUser = currentUserFixtures.userOnly;
 
@@ -211,12 +208,10 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
-
     await screen.findByText("MyReviews");
     const link = screen.getByText("MyReviews");
     expect(link).toBeInTheDocument();
     expect(link.getAttribute("href")).toBe("/myreviews");
-
   });
 
   test("Placeholder link does NOT show when not logged in", async () => {

--- a/frontend/src/tests/pages/ModeratePage.test.js
+++ b/frontend/src/tests/pages/ModeratePage.test.js
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import ModeratePage from "main/pages/ModeratePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ModeratePage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ModeratePage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("moderate page not yet implemented");
+  });
+});


### PR DESCRIPTION
## This PR is based off of #56, please merge that one before reviewing this one
- In order for the dokku deployment to work, this PR has to include commits from #56. That is why it looks like there are more files changed than there should be.
- This PR only creates a simple placeholder page at the url path /moderate only visible to admins.
- Dokku deployment: https://projdining-reviews-frontend4.dokku-14.cs.ucsb.edu/

Closes #16 
This PR closes subissue #16 which inherits from epic #41
This PR creates a placeholder page for review moderation. The placeholder page looks like this:
<img width="763" alt="image" src="https://github.com/user-attachments/assets/d035a751-7baa-4768-97a9-c6f3e681fe94">
The Moderate page has a link in the navbar that is visible to admins only.

## This PR is based off of #56, please merge that one before reviewing this one