### PR TITLE
MenuItem Placeholder Page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,7 +6,7 @@ import DiningCommonsIndexPage from "main/pages/Dining/DiningCommonsIndexPage";
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
-import MenuItemPage from "main/pages/MenuItemPage"
+import MenuItemPage from "main/pages/MenuItemPage";
 import MyReviewsPage from "main/pages/MyReviews/MyReviewsPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
@@ -22,7 +22,11 @@ function App() {
       <Routes>
         <Route exact path="/" element={<HomePage />} />
         <Route exact path="/profile" element={<ProfilePage />} />
-        <Route exact path="/diningcommons/:dateTime/:diningCommonsCode/:meal" element={<MenuItemPage />} />
+        <Route
+          exact
+          path="/diningcommons/:dateTime/:diningCommonsCode/:meal"
+          element={<MenuItemPage />}
+        />
         <>
           <Route
             exact

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import AdminUsersPage from "main/pages/AdminUsersPage";
 import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
+import MenuItemPage from "main/pages/MenuItemPage"
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -20,6 +21,7 @@ function App() {
       <Routes>
         <Route exact path="/" element={<HomePage />} />
         <Route exact path="/profile" element={<ProfilePage />} />
+        <Route exact path="/diningcommons/:dateTime/:diningCommonsCode/:meal" element={<MenuItemPage />} />
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <Route exact path="/admin/users" element={<AdminUsersPage />} />
         )}

--- a/frontend/src/main/pages/MenuItemPage.js
+++ b/frontend/src/main/pages/MenuItemPage.js
@@ -1,0 +1,17 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+
+export default function MenuItemPage() {
+  // Stryker disable all : placeholder for future implementation
+  let { dateTime } = useParams();
+  let { diningCommonsCode } = useParams();
+  let { meal } = useParams();
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Menu Item page not yet implemented for the following info</h1>
+        <>{dateTime}   /   {diningCommonsCode}   /   {meal}</>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/main/pages/MenuItemPage.js
+++ b/frontend/src/main/pages/MenuItemPage.js
@@ -10,7 +10,9 @@ export default function MenuItemPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Menu Item page not yet implemented for the following info</h1>
-        <>{dateTime}   /   {diningCommonsCode}   /   {meal}</>
+        <>
+          {dateTime} / {diningCommonsCode} / {meal}
+        </>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/pages/MenuItemPage.test.js
+++ b/frontend/src/tests/pages/MenuItemPage.test.js
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import MenuItemPage from "main/pages/MenuItemPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MenuItemPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Menu Item page not yet implemented for the following info");
+
+    // assert
+    expect(
+      screen.getByText("Menu Item page not yet implemented for the following info"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tests/pages/MenuItemPage.test.js
+++ b/frontend/src/tests/pages/MenuItemPage.test.js
@@ -38,11 +38,15 @@ describe("MenuItemPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Menu Item page not yet implemented for the following info");
+    await screen.findByText(
+      "Menu Item page not yet implemented for the following info",
+    );
 
     // assert
     expect(
-      screen.getByText("Menu Item page not yet implemented for the following info"),
+      screen.getByText(
+        "Menu Item page not yet implemented for the following info",
+      ),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
# Frontend 3

### Dokku Deployment

[Dokku Link](https://proj-dining-menu-display-frontend-3.dokku-14.cs.ucsb.edu/diningcommons/2021-01-01/ortega/lunch)

You can change the 2021-01-01, ortega, and lunch values in the link and see how the page changes. This will allow us to use the parameters in our code later.

Closes #47 which inherits from #42


### MenuItemPage Placeholder
Simple view of what the home page looks like with the table on it:

**Menu Item Page not implemented yet for the following info**
dateTime   /   diningCommonsCode   /   meal

Created a simple placeholder page that grabs info from the url

### Testing:
Ran all three tests and code passes all three tests locally:
```
npm test
npx stryker run
npm run coverage
```